### PR TITLE
Add check for linux/freebsd systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 module.exports = () => {
 	const env = process.env;
 
-	if (process.platform === 'darwin') {
+	if (process.platform === 'darwin' || process.platform === 'linux' || process.platform === 'freebsd') {
 		return env.SHELL || '/bin/bash';
 	}
 


### PR DESCRIPTION
Linux/freebsd have default shell of bash . So the check is added . 
Source https://nodejs.org/api/process.html#process_process_platform
